### PR TITLE
Fixes issues that prevented a clean build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "FW/ProjectName/lib/lib-soogh"]
+	path = FW/ProjectName/lib/lib-soogh
+	url = https://github.com/knifter/lib-soogh.git
+[submodule "FW/ProjectName/lib/lib-Tools"]
+	path = FW/ProjectName/lib/lib-Tools
+	url = https://github.com/knifter/lib-Tools.git

--- a/FW/ProjectName/def_version.py
+++ b/FW/ProjectName/def_version.py
@@ -1,22 +1,33 @@
 import subprocess
 import datetime
+from sys import stderr
 
 #(part of) GIT revision
-revision = (
-    subprocess.check_output(["git", "rev-parse", "HEAD"])
-    .strip()
-    .decode("utf-8")
-)
-print(f'-DGIT_REVISION="{revision[-8:]}"');
+try:
+    revision = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"])
+        .strip()
+        .decode("utf-8")
+    )[-8:]
+except subprocess.CalledProcessError:
+    revision = "unknownrevision"
+    print("Warning: Could not get git commit", file=stderr)
 
-branch = (
-    subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-    .strip()
-    .decode("utf-8")
-)
-print(f'-DGIT_BRANCH="{branch}"');
+try:
+    branch = (
+        subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        .strip()
+        .decode("utf-8")
+    )
+except subprocess.CalledProcessError:
+    print("Warning: Could not get git branch", file=stderr)
+    branch = "unknownbranch"
+    
 
 #date
 curr_date = datetime.datetime.now()
 datetime = "%02d%02d%02d" % (curr_date.year, curr_date.month, curr_date.day)
+
 print(f'-DBUILD_DATETIME="{datetime}"');
+print(f'-DGIT_REVISION="{revision}"');
+print(f'-DGIT_BRANCH="{branch}"');

--- a/FW/ProjectName/include/config.h
+++ b/FW/ProjectName/include/config.h
@@ -27,9 +27,9 @@
 #define PIN_MISO				GPIO_NUM_13
 #define PIN_SCLK				GPIO_NUM_14
 
-#define PIN_BTN_A				GPIO_NUM_34
-#define PIN_BTN_B 				GPIO_NUM_35
-#define PIN_BTN_C 				GPIO_NUM_36
+#define PIN_BTN_A				GPIO_NUM_39
+#define PIN_BTN_B 				GPIO_NUM_38
+#define PIN_BTN_C 				GPIO_NUM_37
 
 #define PIN_SPEAKER             GPIO_NUM_25
 

--- a/FW/ProjectName/platformio.ini
+++ b/FW/ProjectName/platformio.ini
@@ -17,8 +17,7 @@
 
 [platformio]
 ; default_envs = core2touch
-default_envs = m5stack-core-esp32
-
+default_envs = core
 [env]
 platform = espressif32
 framework = arduino
@@ -34,7 +33,9 @@ build_flags =
 	!python def_version.py
 lib_deps =
 	https://github.com/lvgl/lvgl.git#release/v8.3
-    	https://github.com/lovyan03/LovyanGFX
+	https://github.com/lovyan03/LovyanGFX
+	SPI
+	Wire
 monitor_speed = 115200
 monitor_filter = esp32_exception_decoder
 

--- a/FW/ProjectName/src/main.cpp
+++ b/FW/ProjectName/src/main.cpp
@@ -3,7 +3,6 @@
 #include "config.h"
 #include "globals.h"
 #include "settings.h"
-#include "pid.h"
 #include "screens.h"
 
 //#include "tools-log.h"


### PR DESCRIPTION
- Fixed the default platformio environment and added dependencies on the SPI and Wire libraries
- Added lib-soogh and lib-tool as git submodules
- Fixed main.cpp to not include pid.h
- Changed the A,B and C button IO Pin to the one for the M5 Core Metal
- Improved def_version.py to work when project is not in a git repository